### PR TITLE
Only write the config if the value is present in the attributes (environ...

### DIFF
--- a/libraries/write_solum_config.rb
+++ b/libraries/write_solum_config.rb
@@ -7,7 +7,7 @@ module Extensions
       config = ''
       node[:openstack][:paas][:config][section].each do |key, value|
         config << "#{key}=#{value}\n"
-      end
+      end if node[:openstack][:paas][:config][section]
       config
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'paul.czarkowski@rackspace.com'
 license          'Apache2'
 description      'Installs/Configures Openstack Solum'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.14'
+version          '0.2.15'
 
 %w(apt git python build-essential runit libarchive).each do |dep|
   depends dep


### PR DESCRIPTION
...ment)

This is necessary when the attribute does not exist in environment.json but we still expect to write it out.